### PR TITLE
Proposal for aggregations

### DIFF
--- a/docs/aggregations.md
+++ b/docs/aggregations.md
@@ -13,7 +13,11 @@ Counts the number of records in the table.  If a `where` clause is specified, on
     is_active: true
   }
 }
+
+// e.g.
+// => 3980
 ```
+
 
 
 ## Sum
@@ -24,12 +28,15 @@ Determines the [sum](https://en.wikipedia.org/wiki/Summation) of the specified n
 
 ```javascript
 {
-  sum: 'products',
-  from: 'users',
+  sum: 'pre_tax_total',
+  from: 'orders',
   where: {
     is_active: true
   }
 }
+
+// e.g.
+// => 9385383.20
 ```
 
 ## Avg
@@ -47,4 +54,7 @@ Determines the [average](https://en.wikipedia.org/wiki/Arithmetic_mean) of the s
     is_active: true
   }
 }
+
+// e.g.
+// => 37.2398
 ```

--- a/docs/aggregations.md
+++ b/docs/aggregations.md
@@ -1,68 +1,50 @@
 ## Aggregations
 
-> NOTE: this is a placeholder as I am still working though the exact interface for aggregations
 
 #### Count
 
-Performs a count on the specified attribute.
+Counts the number of records in the table.  If a `where` clause is specified, only records which match will be counted.
 
 ```javascript
 {
-  count: [
-    'active'
-  ],
-  from: 'users'
+  count: true,
+  from: 'users',
+  where: {
+    is_active: true
+  }
 }
 ```
 
-#### Min
-
-Gets the minimum value for the specified attribute.
-
-```javascript
-{
-  min: [
-    'age'
-  ],
-  from: 'users'
-}
-```
-
-#### Max
-
-Gets the maximum value for the specified attribute.
-
-```javascript
-{
-  max: [
-    'age'
-  ],
-  from: 'users'
-}
-```
 
 ## Sum
 
-Retrieve the sum of the values of a given attribute.
+Determines the [sum](https://en.wikipedia.org/wiki/Summation) of the specified numeric field across all records in the table; or if a `where` clause is specified, only across matching records.
+
+> The specified field should contain only numbers.  In most databases, `null`/`undefined` values will be ignored for the purpose of this calculation (i.e. counted as `0`).
 
 ```javascript
 {
-  sum: [
-    'products'
-  ],
-  from: 'users'
+  sum: 'products',
+  from: 'users',
+  where: {
+    is_active: true
+  }
 }
 ```
 
 ## Avg
 
-Retrieve the average of the values of a given attribute.
+Determines the [average](https://en.wikipedia.org/wiki/Arithmetic_mean) of the specified numeric field across all records in the table; or if a `where` clause is specified, only across matching records.
+
+> The specified field should contain only numbers.  In most databases, `null`/`undefined` values will simply be excluded from the calculation.
+
 
 ```javascript
 {
-  avg: [
-    'age'
-  ],
-  from: 'users'
+  avg: 'age',
+  from: 'users',
+  where: {
+    is_active: true
+  }
 }
 ```


### PR DESCRIPTION
#### In general:
- Replaces all mention of "attributes" with "fields" to avoid confusion.
- Adds example result for each type of aggregation query
#### `min` and `max`
- Gets rid of them.  Reasoning: This is easy to do by hand using e.g. `{sort: ['age DESC'], select: ['age'], limit: 1 }`, and then grabbing `results[0]&&results[0][age]`.  Since there's no group by anyway, I think the benefits of removing complexity far outweigh any convenience we'd get by being able to have two different ways to do the same thing)
#### `sum` and `avg`
- Clarifies that sum and avg should only be used w/ numeric fields (attempting to use them for anything else might work, but it's database-specific and not guaranteed). 
- adds `where` to the documented usage.
- replaces `['fieldName']` with `fieldName`.  Since you can't use groupBy anyway, the advantage of being able to get a simple numeric response far outweighs the ability to calculate the aggregate sum/mean of more than one field at once (most of the time when you're doing that, you'll need more customizability anyway, or want to combine it with other stuff.)
#### `count`
- Changes mention of fields from `count`; instead changing syntax to `count: true`.  Also adds `where` to documented usage.
