### PR TITLE
criteria proposal.  remove mention of range (see commit comment for m…

### DIFF
--- a/docs/criteria.md
+++ b/docs/criteria.md
@@ -90,20 +90,9 @@ A query may also specify a comparison operator to be used. Operators are specifi
 }
 ```
 
-* Between `<`/`>` selects records whose field is between the specified values (exclusive).
+> To filter by range, and to combine multiple different sub-attribute modifiers in general, use `and` (described below).
 
-```javascript
-{
-  select: ['*'],
-  from: 'users',
-  where: {
-    age: {
-      '>': 64,
-      '<': 101
-    }
-  }
-}
-```
+
 
 
 #### Conditions
@@ -204,6 +193,30 @@ You can mix both `AND` and `OR` statements together to form complex where clause
   }
 }
 ```
+
+* It also allows you to combine multiple sub-attribute modifiers:
+
+```javascript
+{
+  select: ['*'],
+  from: 'users',
+  where: {
+    and: [
+      {
+        age: { '>': 64 }
+      },
+      {
+        age: { '<=': 101 }
+      },
+      {
+        age: { '>': 64 }
+      }
+    ]
+  }
+}
+```
+
+
 
 * `NOT` can be used to negate a condition.
 

--- a/docs/criteria.md
+++ b/docs/criteria.md
@@ -90,7 +90,7 @@ A query may also specify a comparison operator to be used. Operators are specifi
 }
 ```
 
-> To filter by range, and to combine multiple different sub-attribute modifiers in general, use `and` (described below).
+> To filter by range and, more generally, to combine multiple operators (e.g. `>`/`<`/`in`/etc), use `and` (described below).
 
 
 


### PR DESCRIPTION
…ore info)
- remove mention of special range queries and instead suggest using `and` to combine operators (e.g. `>`/`<`/`in`/etc) in general.  Still explicitly calls out how to do a range query in docs.
